### PR TITLE
Fix jar template issue in xalan build

### DIFF
--- a/xalan/Makefile
+++ b/xalan/Makefile
@@ -81,7 +81,7 @@ java: $(DIST_JAR)
 
 $(JAR): $(JAVA_SOURCES) | $(BUILD_DIR) java_deps_dist annotations_dist
 	@echo "building j2objc_xalan.jar"
-	@stage_dir=`mktemp -d -t j2objc-xalan`; \
+	@stage_dir=`mktemp -d -t j2objc-xalan.XXXXXXX`; \
 	$(JAVAC) -sourcepath $(SOURCEPATH) -encoding UTF-8 \
 	    -cp $(DIST_JAR_DIR)/j2objc_annotations.jar -d $$stage_dir \
 	    -source 1.7 -target 1.7 -bootclasspath $(DIST_JAR_DIR)/jre_emul.jar $^; \


### PR DESCRIPTION
Fixes this problem when building j2objc locally and in CI:

```
Building libxalan.a
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/lipo -create /Users/matt.fluet/repo/cross-platform/j2objc/xalan/build_result/objs-appletvos/libxalan.a /Users/matt.fluet/repo/cross-platform/j2objc/xalan/build_result/objs-appletvsimulator/libxalan.a -output /Users/matt.fluet/repo/cross-platform/j2objc/xalan/build_result/appletvos/libxalan.a
building j2objc_xalan.jar
mktemp: too few X's in template ‘j2objc-xalan’
```